### PR TITLE
chore(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, actions]
+    groups:
+      actions-minor-patch:
+        update-types: [minor, patch]
+      actions-major:
+        update-types: [major]
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, dev]
+    allow:
+      - dependency-type: development
+    groups:
+      composer-dev-minor-patch:
+        update-types: [minor, patch]
+      composer-dev-major:
+        update-types: [major]
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, prod]
+    allow:
+      - dependency-type: production
+    groups:
+      composer-runtime-minor-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
Добавил еженедельное обновление зависимостей через Dependabot

Для экшенов будет формироваться комплексный ПР с минорными изменениями и патчами. Изменения мажорных версий так же идут батчем в отдельном ПР

Зависимости composer разделены на две группы:

- Под лейблом `dev` обновляются _require-dev_. Мажорные версии изменений объеденяются в один ПР так же как для экшенов
- Под лейблом `prod` обновляются все остальные. Обновление каждой мажорной версии идет индивидуальным ПРом

fyi @fey
